### PR TITLE
Remove boost dependencies from library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+
+# Build directory
+build/
+
+# IDE fodler(s)
+.vscode/

--- a/include/winapi_helpers/utilities.h
+++ b/include/winapi_helpers/utilities.h
@@ -1,0 +1,21 @@
+#pragma once
+#if defined(_WIN32) || defined(_WIN64)
+
+#include <Windows.h>
+
+#include <string>
+
+namespace helpers
+{
+
+void set_memory_profiling();
+void set_console_ctrl_handler(PHANDLER_ROUTINE ctrl_handler);
+
+std::string wstring_to_utf8(const std::wstring& var);
+std::wstring utf8_to_wstring(const std::string& var);
+std::string wstring_to_string(const std::wstring& var);
+std::wstring string_to_wstring(const std::string& var);
+
+} // namespace helpers
+
+#endif // defined(_WIN32) || defined(_WIN64)

--- a/include/winapi_helpers/win_native_api_helper.h
+++ b/include/winapi_helpers/win_native_api_helper.h
@@ -57,7 +57,7 @@ typedef OBJECT_ATTRIBUTES *POBJECT_ATTRIBUTES;
     (p)->Attributes = a;                                \
     (p)->ObjectName = n;                                \
     (p)->SecurityDescriptor = s;                        \
-    (p)->SecurityQualityOfService = NULL;               \
+    (p)->SecurityQualityOfService = nullptr;            \
     }
 
 NTSTATUS (__stdcall *NtUnmapViewOfSection)(IN HANDLE  ProcessHandle, IN PVOID  BaseAddress);

--- a/include/winapi_helpers/win_partition_information.h
+++ b/include/winapi_helpers/win_partition_information.h
@@ -5,7 +5,7 @@
 #include <memory>
 #include <string>
 #include <atomic>
-#include <boost\thread\shared_mutex.hpp>
+#include <shared_mutex>
 
 namespace helpers {
 
@@ -128,7 +128,7 @@ private:
     static std::map<int, PlacementType> system_codes_2_placement_type_;
 
     // protect from updating disk information during reading
-    mutable boost::shared_mutex m_;
+    mutable std::shared_mutex m_;
 };
 
 } // namespace helpers

--- a/include/winapi_helpers/win_ptrs.h
+++ b/include/winapi_helpers/win_ptrs.h
@@ -16,7 +16,7 @@ public:
     /// @brief Allocate raw Windows memory using LoaclAlloc
     explicit WinLocalPtr(size_t sz) : _local_mem(reinterpret_cast<T*>(LocalAlloc(LPTR, sz)))
     {
-        if (_local_mem == NULL) {
+        if (_local_mem == nullptr) {
             throw std::system_error(std::error_code(GetLastError(), std::system_category()),
                 "Unable to allocate on WindowsHeap with LocalAlloc");
         }
@@ -107,7 +107,7 @@ public:
 
     /// @brief Allocate memory for the object of known type using HeapAlloc
     WinHeapPtr() : _raw_mem(reinterpret_cast<T*>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(T)))){
-        if (_raw_mem == NULL) 
+        if (_raw_mem == nullptr) 
         {
             throw_formatted("Unable to allocate Windows heap");
         }
@@ -115,7 +115,7 @@ public:
 
     /// @brief Allocate memory for the object of known size using HeapAlloc
     explicit WinHeapPtr(size_t s) : _raw_mem(reinterpret_cast<T*>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, s))){
-        if (_raw_mem == NULL) 
+        if (_raw_mem == nullptr) 
         {
             throw std::system_error(std::error_code(GetLastError(), std::system_category()),
                 "Unable to allocate Windows heap");

--- a/include/winapi_helpers/win_system_information.h
+++ b/include/winapi_helpers/win_system_information.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <map>
+#include <string>
 
 
 namespace helpers{

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,9 @@
 set(TARGET winapi_helpers)
-
-find_package(Boost ${BOOST_MIN_VERSION} COMPONENTS thread chrono filesystem serialization regex system date_time REQUIRED)
  
 file(GLOB SOURCES *.cpp ../include/${TARGET}/*.h)
  
 include_directories(
-    ${Boost_INCLUDE_DIRS} 
-    ${CMAKE_SOURCE_DIR}/winapi_helpers/include)
+    ${CMAKE_SOURCE_DIR}/include)
  
 add_library(${TARGET} ${SOURCES})
-target_link_libraries(${TARGET} ${Boost_LIBRARIES} Secur32)
+target_link_libraries(${TARGET} Secur32)

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -19,7 +19,7 @@ void helpers::set_memory_profiling()
 #endif
 }
 
-void helpers::set_console_ctrl_handler(ctrl_handler_t ctrl_handler)
+void helpers::set_console_ctrl_handler(PHANDLER_ROUTINE ctrl_handler)
 {
     SetConsoleCtrlHandler(ctrl_handler, TRUE);
 }

--- a/src/win_co_initializer.cpp
+++ b/src/win_co_initializer.cpp
@@ -17,10 +17,10 @@ ComInitializer::ComInitializer(ThreadingModel model)
     HRESULT hres{};
 
     if (ThreadingModel::com_single_thread == model) {
-        hres = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_SPEED_OVER_MEMORY);
+        hres = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_SPEED_OVER_MEMORY);
     }
     else if (ThreadingModel::com_multi_thread == model) {
-        hres = CoInitializeEx(NULL, COINIT_MULTITHREADED | COINIT_SPEED_OVER_MEMORY);
+        hres = CoInitializeEx(nullptr, COINIT_MULTITHREADED | COINIT_SPEED_OVER_MEMORY);
     }
 
     if (FAILED(hres)) {

--- a/src/win_partition_information.cpp
+++ b/src/win_partition_information.cpp
@@ -175,8 +175,8 @@ int NativePartititonInformation::get_physical_drive_number(char windows_drive_le
     system_partition_name_pattern[drive_letter_position] = windows_drive_letter;
     HANDLE partitionHandle = ::CreateFileW(system_partition_name_pattern,
         GENERIC_READ,
-        FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
-        OPEN_EXISTING, 0, NULL);
+        FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
+        OPEN_EXISTING, 0, nullptr);
 
     if (partitionHandle == INVALID_HANDLE_VALUE) {
         return -1;
@@ -188,12 +188,12 @@ int NativePartititonInformation::get_physical_drive_number(char windows_drive_le
     BOOL result = DeviceIoControl(
         partitionHandle,
         IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS,
-        NULL,
+        nullptr,
         0,
         &diskExtents,
         sizeof(diskExtents),
         &read_structure_size,
-        NULL);
+        nullptr);
 
     if (result) {
         return diskExtents.Extents[0].DiskNumber;
@@ -237,8 +237,8 @@ NativePartititonInformation::get_drive_type(int physical_drive_number) const
     HANDLE physical_drive_device = ::CreateFileW(physical_drive_pattern,
         //We need write access to send ATA command to read RPMs
         GENERIC_READ | GENERIC_WRITE,
-        FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
-        OPEN_EXISTING, 0, NULL);
+        FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
+        OPEN_EXISTING, 0, nullptr);
 
     if (physical_drive_device == INVALID_HANDLE_VALUE) {
         return DiskType::UnknownType;
@@ -251,7 +251,7 @@ NativePartititonInformation::get_drive_type(int physical_drive_number) const
     bytesReturned = 0;
     DEVICE_TRIM_DESCRIPTOR dtd = {};
     if (::DeviceIoControl(physical_drive_device, IOCTL_STORAGE_QUERY_PROPERTY,
-        &spqTrim, sizeof(spqTrim), &dtd, sizeof(dtd), &bytesReturned, NULL) &&
+        &spqTrim, sizeof(spqTrim), &dtd, sizeof(dtd), &bytesReturned, nullptr) &&
         bytesReturned == sizeof(dtd)) {
         //Got it
         return dtd.TrimEnabled ? DiskType::SSD : DiskType::HDD;

--- a/src/win_partition_information.cpp
+++ b/src/win_partition_information.cpp
@@ -4,7 +4,6 @@
 #include <winapi_helpers/utilities.h>
 
 
-#include <boost/thread/locks.hpp>
 #include <Windows.h>
 
 #include <cassert>
@@ -37,7 +36,7 @@ std::vector<NativePartititonInformation::NativePartititon>
 NativePartititonInformation::enumerate_partititons() const
 {
     // read lock
-    boost::shared_lock<boost::shared_mutex> lk(m_);
+    std::shared_lock<std::shared_mutex> lk(m_);
     std::vector<NativePartititon> partitions;
     std::transform(partititon_info_.begin(), partititon_info_.end(), std::back_inserter(partitions), [](const auto& part_info) {
         return part_info.second;
@@ -54,7 +53,7 @@ NativePartititonInformation::get_file_partition_info(const std::string& filepath
     char drive_letter = std::toupper(filepath[0]);
 
     // read lock
-    boost::shared_lock<boost::shared_mutex> lk(m_);
+    std::shared_lock<std::shared_mutex> lk(m_);
 
     auto it = partititon_info_.find(drive_letter);
 
@@ -126,7 +125,7 @@ void NativePartititonInformation::collect_partititon_information()
     }
     
     // write lock
-    std::unique_lock<boost::shared_mutex> unique_lk(m_);
+    std::unique_lock<std::shared_mutex> unique_lk(m_);
 
     partititon_info_.clear();
     while (drive_mask) {

--- a/src/win_physical_memory.cpp
+++ b/src/win_physical_memory.cpp
@@ -19,7 +19,7 @@ HANDLE get_physical_memory_handle() {
     RtlInitUnicodeString(&memory_device_string, physical_memory_device_name);
 
     OBJECT_ATTRIBUTES attributes{};
-    InitializeObjectAttributes(&attributes, &memory_device_string, OBJ_CASE_INSENSITIVE, NULL, NULL);
+    InitializeObjectAttributes(&attributes, &memory_device_string, OBJ_CASE_INSENSITIVE, nullptr, nullptr);
 
     NTSTATUS status = NtOpenSection(&physical_memory_native_handle, SECTION_MAP_READ, &attributes);
     if (!NT_SUCCESS(status)) {

--- a/src/win_process_helper.cpp
+++ b/src/win_process_helper.cpp
@@ -22,14 +22,14 @@ bool NativeProcessHelper::execute(const char* executable, bool exec_async /*= fa
 #endif
 
     std::string return_message = WinErrorChecker::last_error_nothrow_boolean(CreateProcessA(
-        NULL,
+        nullptr,
         const_cast<LPSTR>(executable),
-        NULL,	// lpProcessAttributes
-        NULL,	// lpThreadAttributes
+        nullptr,	// lpProcessAttributes
+        nullptr,	// lpThreadAttributes
         FALSE,	// bInheritHandles
         NULL,	// dwCreationFlags
-        NULL,	// lpEnvironment
-        NULL,	// lpCurrentDirectory
+        nullptr,	// lpEnvironment
+        nullptr,	// lpCurrentDirectory
         &si,	// LPSTARTUPINFO
         &pi));	// LPPROCESS_INFORMATION
 
@@ -73,14 +73,14 @@ bool NativeProcessHelper::execute(const wchar_t* executable, bool exec_async /*=
 #endif
 
     std::string return_message = WinErrorChecker::last_error_nothrow_boolean(CreateProcessW(
-        NULL,
+        nullptr,
         const_cast<LPWSTR>(executable),
-        NULL,	// lpProcessAttributes
-        NULL,	// lpThreadAttributes
+        nullptr,	// lpProcessAttributes
+        nullptr,	// lpThreadAttributes
         FALSE,	// bInheritHandles
         NULL,	// dwCreationFlags
-        NULL,	// lpEnvironment
-        NULL,	// lpCurrentDirectory
+        nullptr,	// lpEnvironment
+        nullptr,	// lpCurrentDirectory
         &si,	// LPSTARTUPINFO
         &pi));	// LPPROCESS_INFORMATION
 
@@ -130,7 +130,7 @@ void NativeProcessHelper::pkill(const char* process_name)
             
             HANDLE current_process = OpenProcess(PROCESS_TERMINATE, 0, process_entry.th32ProcessID);
             
-            if (current_process != NULL && process_entry.th32ProcessID != GetCurrentProcessId()) {
+            if (current_process != nullptr && process_entry.th32ProcessID != GetCurrentProcessId()) {
                 TerminateProcess(current_process, 9);
                 CloseHandle(current_process);
             }
@@ -142,7 +142,7 @@ void NativeProcessHelper::pkill(const char* process_name)
 bool NativeProcessHelper::is_admin_mode()
 {
     BOOL run_as_admin = FALSE;
-    PSID administrators_group_sid = NULL;
+    PSID administrators_group_sid = nullptr;
 
     try{
 
@@ -158,7 +158,7 @@ bool NativeProcessHelper::is_admin_mode()
 
         // Determine whether the SID of Administrators group is enabled in 
         // the primary access token of the process
-        WinErrorChecker::last_error_throw_boolean(CheckTokenMembership(NULL, administrators_group_sid, &run_as_admin));
+        WinErrorChecker::last_error_throw_boolean(CheckTokenMembership(nullptr, administrators_group_sid, &run_as_admin));
 
     }
     catch (const std::system_error& e){
@@ -176,12 +176,12 @@ bool NativeProcessHelper::elevate_to_admin_mode()
     if (!is_admin_mode()) {
 
         char exe_module_path[MAX_PATH] = {};
-        if (GetModuleFileNameA(NULL, exe_module_path, ARRAYSIZE(exe_module_path))) {
+        if (GetModuleFileNameA(nullptr, exe_module_path, ARRAYSIZE(exe_module_path))) {
             SHELLEXECUTEINFOA elevated_executable_info = {};
             elevated_executable_info.cbSize = sizeof(elevated_executable_info);
             elevated_executable_info.lpVerb = "runas";
             elevated_executable_info.lpFile = exe_module_path;
-            elevated_executable_info.hwnd = NULL;
+            elevated_executable_info.hwnd = nullptr;
             elevated_executable_info.nShow = SW_NORMAL;
 
             if (!ShellExecuteExA(&elevated_executable_info))

--- a/src/win_registry_helper.cpp
+++ b/src/win_registry_helper.cpp
@@ -135,9 +135,9 @@ std::optional<bool> helpers::RegistryKey::is_value_exist(const std::string& valu
     LONG ret_code = ::RegQueryValueExA(hkey_->key, // Root key
         value_name.c_str(), // value name
         0,          // reserved, == 0
-        NULL,       // receive type - nothing, just check
-        NULL,       // receive here value - also nothing, just check
-        NULL);      // size is null
+        nullptr,       // receive type - nothing, just check
+        nullptr,       // receive here value - also nothing, just check
+        nullptr);      // size is null
 
     if (ERROR_SUCCESS == ret_code) {
         return true;
@@ -223,8 +223,8 @@ bool RegistryKey::load_from_file(const string &file_path, const std::string& key
 bool RegistryKey::create_key(const string &key_name) const
 {
     return WinErrorChecker::retbool_nothrow_retcode(RegCreateKeyExA(hkey_->key,
-        key_name.data(), 0, NULL, REG_OPTION_NON_VOLATILE,
-        KEY_ALL_ACCESS, NULL, &hkey_->key, NULL));
+        key_name.data(), 0, nullptr, REG_OPTION_NON_VOLATILE,
+        KEY_ALL_ACCESS, nullptr, &hkey_->key, nullptr));
 }
 
 bool RegistryKey::delete_tree(const std::string& key)
@@ -242,7 +242,7 @@ bool RegistryKey::delete_tree(const std::string& key)
 
     LONG ret_code = RegOpenKeyExA(root, key_name.c_str(), 0, KEY_ALL_ACCESS, &holder);
     if (ERROR_SUCCESS == ret_code) {
-        ret_code = RegDeleteTree(holder, NULL);
+        ret_code = RegDeleteTree(holder, nullptr);
         if (ERROR_SUCCESS != ret_code) {
             return false;
         }
@@ -277,7 +277,7 @@ bool RegistryKey::save_to_file(const std::string &file_path, const std::string& 
     filename += key_name;
     return WinErrorChecker::retbool_nothrow_retcode(RegSaveKeyA(hkey_->key,
         filename.c_str(),
-        NULL));
+        nullptr));
 }
 
 std::optional<unsigned long> helpers::RegistryKey::get_dword_value(const std::string& key_name) const
@@ -405,7 +405,7 @@ std::optional<RegistryKey::multi_sz> RegistryKey::get_multi_string_value(const s
 
 bool RegistryKey::enable_backup_privilege() const
 {
-    HANDLE handle_token_ = NULL;
+    HANDLE handle_token_ = nullptr;
     if (!OpenProcessToken(
         GetCurrentProcess(),
         TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
@@ -415,7 +415,7 @@ bool RegistryKey::enable_backup_privilege() const
     }
 
     TOKEN_PRIVILEGES privileges_token_;
-    if (!LookupPrivilegeValue(NULL, SE_BACKUP_NAME, &privileges_token_.Privileges[0].Luid)) {
+    if (!LookupPrivilegeValue(nullptr, SE_BACKUP_NAME, &privileges_token_.Privileges[0].Luid)) {
         CloseHandle(handle_token_);
         return false;
     }
@@ -423,7 +423,7 @@ bool RegistryKey::enable_backup_privilege() const
     privileges_token_.PrivilegeCount = 1;
     privileges_token_.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
 
-    if (!AdjustTokenPrivileges(handle_token_, FALSE, &privileges_token_, 0, NULL, 0)) {
+    if (!AdjustTokenPrivileges(handle_token_, FALSE, &privileges_token_, 0, nullptr, 0)) {
         CloseHandle(handle_token_);
         return false;
     }
@@ -434,7 +434,7 @@ bool RegistryKey::enable_backup_privilege() const
 
 bool RegistryKey::enable_restore_privilege() const
 {
-    HANDLE handle_token_ = NULL;
+    HANDLE handle_token_ = nullptr;
     if (!OpenProcessToken(
         GetCurrentProcess(),
         TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
@@ -445,7 +445,7 @@ bool RegistryKey::enable_restore_privilege() const
 
     TOKEN_PRIVILEGES privileges_token_;
     if (!LookupPrivilegeValue(
-        NULL,
+        nullptr,
         SE_RESTORE_NAME,
         &privileges_token_.Privileges[0].Luid)) {
         CloseHandle(handle_token_);
@@ -455,7 +455,7 @@ bool RegistryKey::enable_restore_privilege() const
     privileges_token_.PrivilegeCount = 1;
     privileges_token_.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
 
-    if (!AdjustTokenPrivileges(handle_token_, FALSE, &privileges_token_, 0, NULL, 0)) {
+    if (!AdjustTokenPrivileges(handle_token_, FALSE, &privileges_token_, 0, nullptr, 0)) {
         CloseHandle(handle_token_);
         return false;
     }
@@ -480,9 +480,9 @@ std::optional<RegistryKey::values_list> RegistryKey::enumerate_subkeys() const
         error_string = WinErrorChecker::last_error_nothrow_retcode(RegEnumKeyExA(hkey_->key, i,
             subkey_name_buffer,
             &subkey_name_size,
-            NULL,
-            NULL,
-            NULL,
+            nullptr,
+            nullptr,
+            nullptr,
             &last_change_time));
 
         // probably multithreading (very rare) issue
@@ -517,9 +517,9 @@ std::optional<RegistryKey::values_list> RegistryKey::enumerate_values() const
         error_string = WinErrorChecker::last_error_nothrow_retcode(RegEnumValueA(hkey_->key, i,
             subvalue_name_buffer,
             &subvalue_name_size,
-            NULL,
-            NULL,
-            NULL,
+            nullptr,
+            nullptr,
+            nullptr,
             &value_type));
 
         // probably multithreading (very rare) issue
@@ -555,7 +555,7 @@ std::pair<DWORD, DWORD> RegistryKey::count_subvalues() const
         hkey_->key,
         class_name_in_buffer,
         &class_name_length,
-        NULL, // reserved 
+        nullptr, // reserved 
         &number_of_subkeys_,
         &longest_subkey_size,
         &longest_class_string,

--- a/src/win_service_helper.cpp
+++ b/src/win_service_helper.cpp
@@ -19,9 +19,9 @@ class ScmManager{
 public:
 
 	/// @brief Service Control Manager initializer
-    explicit ScmManager(DWORD desired_access) :_scm_handle(OpenSCManager(NULL, // local computer
+    explicit ScmManager(DWORD desired_access) :_scm_handle(OpenSCManager(nullptr, // local computer
 		// servicesActive database 
-		NULL,
+		nullptr,
 		// full access rights 
         desired_access))
     {
@@ -84,16 +84,16 @@ private:
 std::optional<bool> NativeServiceHelper::is_admin_access()
 {
 
-    SC_HANDLE service_handle = OpenSCManager(NULL, // local computer
+    SC_HANDLE service_handle = OpenSCManager(nullptr, // local computer
         // servicesActive database 
-        NULL,
+        nullptr,
         // full access rights 
         SC_MANAGER_ALL_ACCESS);
 
-    if ((service_handle == NULL) && (ERROR_ACCESS_DENIED == GetLastError())){
+    if ((service_handle == nullptr) && (ERROR_ACCESS_DENIED == GetLastError())){
         return false;
     }
-    else if (service_handle == NULL){
+    else if (service_handle == nullptr){
         // OpenService failed
         return {};
     }
@@ -147,10 +147,10 @@ std::optional<bool> NativeServiceHelper::is_service_registered(const std::string
 
     SC_HANDLE service_handle = OpenServiceA(scm.handle(), service_name.c_str(), SERVICE_QUERY_STATUS);
 
-	if ((service_handle == NULL) && (ERROR_SERVICE_DOES_NOT_EXIST == GetLastError())){
+	if ((service_handle == nullptr) && (ERROR_SERVICE_DOES_NOT_EXIST == GetLastError())){
 		return false;
 	}
-    else if (service_handle == NULL) {
+    else if (service_handle == nullptr) {
         // OpenService failed
         return false;
     };
@@ -300,7 +300,7 @@ bool NativeServiceHelper::start_service(const std::string& service_name)
 		0,
 
 		// no arguments 
-		NULL)){
+		nullptr)){
 
         // StartService failed
 		return false;
@@ -510,7 +510,7 @@ bool NativeServiceHelper::register_service(const std::string& service_name,
     const std::string& account_name)
 {
 	char service_binary[MAX_PATH] = {};
-	if (!GetModuleFileNameA(NULL, service_binary, MAX_PATH)) {
+	if (!GetModuleFileNameA(nullptr, service_binary, MAX_PATH)) {
         // Cannot install service
 		return false;
 	}
@@ -535,14 +535,14 @@ bool NativeServiceHelper::register_service(const std::string& service_name,
 		SERVICE_AUTO_START,        // start type 
 		SERVICE_ERROR_NORMAL,      // error control type 
 		service_binary,            // path to service's binary 
-		NULL,                      // no load ordering group 
-		NULL,                      // no tag identifier 
-		NULL,                      // no dependencies 
-        // LocalSystem account if NULL, "DomainName\UserName" otherwise
-        account_name.empty() ? NULL : account_name.c_str(),
-		NULL);                     // no password 
+		nullptr,                      // no load ordering group 
+		nullptr,                      // no tag identifier 
+		nullptr,                      // no dependencies 
+        // LocalSystem account if nullptr, "DomainName\UserName" otherwise
+        account_name.empty() ? nullptr : account_name.c_str(),
+		nullptr);                     // no password 
 
-	if (schService == NULL) {
+	if (schService == nullptr) {
         // register_service: CreateService failed
 		return false;
 	}
@@ -568,7 +568,7 @@ bool NativeServiceHelper::delete_service(const std::string& service_name)
 		service_name.c_str(),  // name of service 
 		DELETE);               // need delete access 
 
-	if (service_handle == NULL){
+	if (service_handle == nullptr){
         // delete_service: OpenService failed
 		return false;
 	}

--- a/src/win_special_path_helper.cpp
+++ b/src/win_special_path_helper.cpp
@@ -2,7 +2,7 @@
 
 #include <winapi_helpers/win_special_path_helper.h>
 #include <winapi_helpers/win_service_helper.h>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include <Windows.h>
 #include <shlobj.h>
@@ -88,9 +88,9 @@ std::wstring NativePathHelpers::get_common_appdata_path()
 std::wstring NativePathHelpers::create_root_tempdir()
 {
     std::wstring default_temp(L"C:/Temp");
-    boost::system::error_code error;
-    if (!boost::filesystem::is_directory(default_temp)) {
-        boost::filesystem::create_directory(default_temp, error);
+    std::error_code error;
+    if (!std::filesystem::is_directory(default_temp)) {
+        std::filesystem::create_directory(default_temp, error);
     }
     return default_temp;
 }

--- a/src/win_special_path_helper.cpp
+++ b/src/win_special_path_helper.cpp
@@ -39,7 +39,7 @@ std::wstring NativePathHelpers::get_home_path()
 
     std::wstring home_path;
     static wchar_t user_home_path[MAX_PATH + 1] = {};
-    if (::SHGetSpecialFolderPathW(NULL, user_home_path, CSIDL_PROFILE, FALSE)) {
+    if (::SHGetSpecialFolderPathW(nullptr, user_home_path, CSIDL_PROFILE, FALSE)) {
         home_path = user_home_path;
     }
 
@@ -59,7 +59,7 @@ std::wstring NativePathHelpers::get_appdata_path(int special_path_type, bool ign
 
     std::wstring appdata_path;
     static wchar_t user_appdata_path[MAX_PATH + 1] = {};
-    if (::SHGetSpecialFolderPathW(NULL, user_appdata_path, special_path_type, FALSE)) {
+    if (::SHGetSpecialFolderPathW(nullptr, user_appdata_path, special_path_type, FALSE)) {
         appdata_path = user_appdata_path;
     }
 

--- a/src/win_system_information.cpp
+++ b/src/win_system_information.cpp
@@ -29,7 +29,7 @@ bool helpers::is_x32_application_on_x64()
     LPFN_ISWOW64PROCESS fnIsWow64Process = 
         (LPFN_ISWOW64PROCESS) GetProcAddress(GetModuleHandle(TEXT("kernel32")),"IsWow64Process");
 
-    if(NULL != fnIsWow64Process){
+    if(nullptr != fnIsWow64Process){
         if (!fnIsWow64Process(GetCurrentProcess(), &is_wow_64)){
             //handle error
         }


### PR DESCRIPTION
In this PR, boost dependencies were removed from the library and were replaced with C++17 features. Also, a missing header was added and NULL pointers were replaced with nullptr.